### PR TITLE
scripts/entrypoint.sh: Fix ioncorrect variable name

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -3,7 +3,7 @@
 if [[ -v USER_ID ]]; then
 	usermod -u $USER_ID coreboot
 fi
-if [[ -v GROUP ]]; then
+if [[ -v GROUP_ID ]]; then
 	groupmod -g $GROUP_ID coreboot
 fi
 


### PR DESCRIPTION
To set the GROUP_ID for the coreboot user one has to pass two variables to docker environment: GROUP and GROUP_ID. Most likely it was a copy-pasta error, which can be fixed by using GROUP_ID in the IF condition.