### PR TITLE
Dockerfile: use more recent version of coreboot-sdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM coreboot/coreboot-sdk:2021-09-23_b0d87f753c
+FROM coreboot/coreboot-sdk:2024-02-18_732134932b
 
 MAINTAINER Michał Kopeć <michal.kopec@3mdeb.com>
 


### PR DESCRIPTION
This is unlikely to be a good fix. What I'm trying to do is essentially operate on one version of the container while preparing HWIO2024 training with Odroid-H4+.

At least it builds without issues and correctly exposes vboot tools. The next step should be to find why `/vboot` is unavailable on a more recent dasharo-sdk.

Since coreboot-sdk is based on Debian sid, v1.1.2 cannot be rebuilt.