### PR TITLE
WIP: Dasharo(coreboot+SeaBIOS) for PC Engines support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: ['main']
     tags:
       - v*.*.*
+      - v*.*.*-rc*
 
 env:
   REGISTRY: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,8 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y \
     gpg \
+    guilt \
     imagemagick \
-    uuid-runtime \
-    unzip \
     libxcb-icccm4 \
     libxcb-image0 \
     libxcb-keysyms1 \
@@ -20,6 +19,8 @@ RUN apt-get update && \
     libxcb-xinerama0 \
     libxcb-xkb1 \
     libxkbcommon-x11-0 \
+    unzip \
+    uuid-runtime \
     && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM coreboot/coreboot-sdk:2024-03-30_cccada28f7
+FROM coreboot/coreboot-sdk:2024-05-20_b4949d3de5
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM coreboot/coreboot-sdk:2024-02-18_732134932b
+FROM coreboot/coreboot-sdk:2024-03-30_cccada28f7
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM coreboot/coreboot-sdk:2024-05-20_b4949d3de5
+FROM coreboot/coreboot-sdk:2024-03-30_cccada28f7
 
 USER root
 


### PR DESCRIPTION
These patches support the upcoming 24.08.00.01 and dasharo-pq method of building coreboot (guilt is required). To unblock progress while waiting for reviewers, I'm also adding support for building rc containers.

I keep it in WIP since it has not yet been proven.