### PR TITLE
Add DCU requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -146,6 +146,7 @@ RUN \
 		uuid-runtime \
 		golang-go \
 		bsdextrautils \
+		wget \
 		zlib1g-dev \
 		&& \
 		apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,6 +123,7 @@ RUN \
 		binutils \
 		ca-certificates \
 		clang \
+		file \
 		g++ \
 		gcc \
 		git \


### PR DESCRIPTION
[DCU ](https://github.com/Dasharo/dcu) uses dasharo-sdk to function.

It does not function with the newest releases where `file` and `wget` are not available: https://github.com/Dasharo/dcu/pull/25