### PR TITLE
Dockerfile: Add ssh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -154,6 +154,7 @@ RUN \
 		bison \
 		libelf-dev \
 		bc \
+		openssh-client \
 		&& \
 		apt-get clean && \
 		rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -155,6 +155,7 @@ RUN \
 		libelf-dev \
 		bc \
 		openssh-client \
+		jq \
 		&& \
 		apt-get clean && \
 		rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Needed for cloning some repos during the build process.